### PR TITLE
Added some improvements

### DIFF
--- a/lib/nbv.js
+++ b/lib/nbv.js
@@ -107,7 +107,7 @@ var nbv = (function() {
             'margin-bottom: 0',
             'margin-top: 0',
             'border-radius: 2px',
-            'overflow-x: scroll',
+            //'overflow-x: scroll',
             'min-height: .85em'
             ].join(';'));
         var code = d.createElement('code');
@@ -184,7 +184,7 @@ var nbv = (function() {
                     break;
 
                 case 'text/html':
-                    dm.style.overflow = 'scroll';
+                    //dm.style.overflow = 'scroll';
                     dm.innerHTML = dt.data[fmt].join('');
 
                     // we may have generated some HTML tables we need to style

--- a/lib/nbv.js
+++ b/lib/nbv.js
@@ -203,7 +203,10 @@ var nbv = (function() {
                         }
 
                     }
-
+                    break;
+                
+                case 'image/svg+xml':
+                    dm.innerHTML = dt.data[fmt].join('');
                     break;
 
                 default:

--- a/lib/nbv.js
+++ b/lib/nbv.js
@@ -107,7 +107,6 @@ var nbv = (function() {
             'margin-bottom: 0',
             'margin-top: 0',
             'border-radius: 2px',
-            //'overflow-x: scroll',
             'min-height: .85em'
             ].join(';'));
         var code = d.createElement('code');
@@ -184,7 +183,6 @@ var nbv = (function() {
                     break;
 
                 case 'text/html':
-                    //dm.style.overflow = 'scroll';
                     dm.innerHTML = dt.data[fmt].join('');
 
                     // we may have generated some HTML tables we need to style

--- a/lib/nbv.js
+++ b/lib/nbv.js
@@ -212,7 +212,7 @@ var nbv = (function() {
                 default:
                     if (fmt.startsWith('image/')) {
                         dm = d.createElement('img');
-                        dm.setAttribute('src', 'data:' + fmt + ';base64,' + dt.data[fmt]);
+                        dm.setAttribute('src', 'data:' + fmt + ';base64,' + dt.data[fmt].join(''));
                         break;
                     }
                     console.error('unexpected format: ' + fmt);


### PR DESCRIPTION
I've added some improvements to the rendering of the notebook:

SVG was not correctly rendered:
* before: [image](http://imgur.com/lqBG704)
* after: [image](http://imgur.com/3YKtaLj)

There was an ugly scroll even when it is unnecessary:
* before: [image](http://imgur.com/82ajen7)
* after: [image](http://imgur.com/h2R6Oll)

Some images, if data was multiline, were not correctly rendered:
* before: [image](http://imgur.com/QUEzYiL)
* after: [image](http://imgur.com/0xGa47G)

Notebook used in the tests: [notebook](http://nbviewer.jupyter.org/github/ipython/ipython/blob/4.0.x/examples/IPython%20Kernel/Rich%20Output.ipynb)