### PR TITLE
Make use of width and height metadata for images

### DIFF
--- a/lib/nbv.js
+++ b/lib/nbv.js
@@ -217,6 +217,16 @@ var nbv = (function() {
                         dm = d.createElement('img');
                         dm.setAttribute('src', 'data:' + fmt + ';base64,' + 
                             ((typeof dt.data[fmt]) == 'string' ? dt.data[fmt] : dt.data[fmt].join('')));
+                        // use width and height attributes supplied in metadata
+                        if (fmt in dt.metadata) {
+                            var metadata = dt.metadata[fmt];
+                            if ('width' in metadata) {
+                                dm.setAttribute('width', metadata.width);
+                            }
+                            if ('height' in metadata) {
+                                dm.setAttribute('height', metadata.height);
+                            }
+                        }
                         break;
                     }
                     console.error('unexpected format: ' + fmt);


### PR DESCRIPTION
If there are width and height attributes set in the metadata of images, they should be used for display. For example, there might be images at higher resolution if the matplotlib figure format is set to 'retina'. I put up a minimum notebook with standard and retina output [here](https://gist.github.com/tuxu/155750c8676eaa79c557bd5ec8fc4235) for testing. Fixes [nbviewer-app#5](https://github.com/tuxu/nbviewer-app/issues/5). 