### PR TITLE
Use the display mode of KaTeX for $$-enclosed math.

### DIFF
--- a/lib/nbv.js
+++ b/lib/nbv.js
@@ -291,10 +291,13 @@ var nbv = (function() {
         return cn;
     }
 
-    function latexer(match, m1, offset, string) {
-        return katex.renderToString(m1, {
-            throwOnError: false, // we do not want to stop rendering because of bad LaTeX
-        });
+    function latexer(isDisplayMode) {
+        return  function replacer(match, m1, offset, string) {
+            return katex.renderToString(m1, {
+                displayMode: isDisplayMode,
+                throwOnError: false, // we do not want to stop rendering because of bad LaTeX
+            });
+        }
     }
 
     function handle_mdown(cell) {
@@ -303,8 +306,8 @@ var nbv = (function() {
         if (Array.isArray(source)) {
             source = source.join('');
         }
-        var latexed = source.replace(/\$\$([\s\S]+?)\$\$/g, latexer); // block-based math
-        latexed = latexed.replace(/\$(.+?)\$/g, latexer); // inline math
+        var latexed = source.replace(/\$\$([\s\S]+?)\$\$/g, latexer(true)); // block-based math
+        latexed = latexed.replace(/\$(.+?)\$/g, latexer(false)); // inline math
         el.innerHTML = marked(latexed);
 
         return el;

--- a/lib/nbv.js
+++ b/lib/nbv.js
@@ -292,7 +292,7 @@ var nbv = (function() {
     }
 
     function latexer(isDisplayMode) {
-        return  function replacer(match, m1, offset, string) {
+        return function replacer(match, m1, offset, string) {
             return katex.renderToString(m1, {
                 displayMode: isDisplayMode,
                 throwOnError: false, // we do not want to stop rendering because of bad LaTeX

--- a/tests/repro-pr46.ipynb
+++ b/tests/repro-pr46.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "above-parker",
+   "metadata": {},
+   "source": [
+    "Repro of [PR #46](https://github.com/kokes/nbviewer.js/pull/46). The change introduces display in [KaTeX](https://katex.org/docs/options.html) for block based math. The most notable changes are: centering, being in a block, and larger sums and integrals."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "copyrighted-wells",
+   "metadata": {},
+   "source": [
+    "We should apply a different parameter to KaTeX for inline math - like this - $\\sum_{x=1}^\\infty x^2 - \\int_0^12\\frac{1}{2-x}$ - and to block based math, like this:\n",
+    "\n",
+    "$$\n",
+    "\\begin{aligned} \n",
+    "2x - 5y &=  8 \\\\ \n",
+    "3x + 9y &=  -12\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    "\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "x&=y           &  w &=z              &  a&=b+c\\\\\n",
+    "2x&=-y         &  3w&=\\frac{1}{2}z   &  a&=b\\\\\n",
+    "-4 + 5x&=2+y   &  w+2&=-1+w          &  ab&=cb\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    "\n",
+    "$$\n",
+    "\\sum_{x=1}^n x^2 = \\ldots\\\\\n",
+    "\\int_0^12 x = \\ldots\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "subtle-alloy",
+   "metadata": {},
+   "source": [
+    "Also, if we use block-based math inline, it will be forced into a block - $$x^2 = \\ldots$$ - like this."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "metric-virtue",
+   "metadata": {},
+   "source": [
+    "Some of the equations above taken from [overleaf.com](https://www.overleaf.com/learn/latex/Aligning%20equations%20with%20amsmath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "herbal-chemistry",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
The $$-enclosed (or said as _block-based_ in the comments) math has not been properly rendered with KaTeX. This patch changes to use the display mode of KaTeX.