### PR TITLE
Handle outputs of non-array multi-line strings.

### DIFF
--- a/lib/nbv.js
+++ b/lib/nbv.js
@@ -286,7 +286,7 @@ var nbv = (function() {
         if (outt === 'stderr') {
             cn.setAttribute('style', 'background-color: #fdd; padding: .5em; white-space: pre-wrap');
         }
-        cn.textContent = dt.text.join('');
+        cn.textContent = Array.isArray(dt.text) ? dt.text.join('') : dt.text;
 
         return cn;
     }

--- a/tests/repro-pr47.ipynb
+++ b/tests/repro-pr47.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test for PR #47\n",
+    "\n",
+    "This ipynb was edited and saved with VSCode (version 1.47.3)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "A multi-line\nstring\n\n"
+    }
+   ],
+   "source": [
+    "print(\"\"\"A multi-line\n",
+    "string\n",
+    "\"\"\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.8.5 64-bit",
+   "language": "python",
+   "name": "python_defaultSpec_1611999024431"
+  },
+  "language_info": {
+   "name": "",
+   "version": "3.8.3-final"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
The text outputs are of multi-line strings, which may be arrays but may not be.
Cf. https://nbformat.readthedocs.io/en/latest/format_description.html#top-level-structure

Note that the Python extension of VSCode yielded such ipynb files that outputs are of non-array multi-line strings.