### PR TITLE
Handle "in-line" math blocks that span multiple lines

### DIFF
--- a/lib/nbv.js
+++ b/lib/nbv.js
@@ -326,7 +326,7 @@ const nbv_constructor = (function(document, deps) {
         var el = d.createElement('div');
         var source = handle_multiline_strings(source);
         var latexed = source.replace(/\$\$([\s\S]+?)\$\$/g, latexer(true)); // block-based math
-        latexed = latexed.replace(/\$(.+?)\$/g, latexer(false)); // inline math
+        latexed = latexed.replace(/\$([\s\S]+?)\$/g, latexer(false)); // inline math
         el.innerHTML = deps.marked(latexed);
 
         return el;


### PR DESCRIPTION
Bring into alignment with vscode and jupyter.

Permit $e^{\lambda t}$  (as before)

Permit multi-line 'in-line' entry (New functionality) such as:

This $
\begin{bmatrix}
  1 & 0 \\
  0 & 1 \\
\end{bmatrix}
$ is an in-line identity matrix.